### PR TITLE
calendar-next-gen#8: Use the requestText method for the deleteEvent method which receives no body

### DIFF
--- a/lib/api/calendars.ts
+++ b/lib/api/calendars.ts
@@ -5,7 +5,7 @@ import { MultiStatusResponse } from '../../types/XMLResponses';
 import { DAVClient } from '../DAVClient';
 import { Partstat } from '../../types/EventPartstat';
 
-const BASE_PATH = '/calendars';
+export const BASE_PATH = '/calendars';
 
 export interface CalendarData {
   href: string;

--- a/lib/api/calendars.ts
+++ b/lib/api/calendars.ts
@@ -82,7 +82,7 @@ export const changeParticipation =
 export const deleteEvent =
   (client: DAVClient) =>
   async (eventPath: string): Promise<string> => {
-    return await client.requestJson({
+    return await client.requestText({
       url: urlJoin(BASE_PATH, eventPath),
       method: 'DELETE',
     });

--- a/test/api/calendar.test.ts
+++ b/test/api/calendar.test.ts
@@ -267,7 +267,7 @@ describe('the deleteEvent method', () => {
 
     await deleteEvent(davClient)(path);
 
-    expect(httpClient.requestJson).toHaveBeenCalledWith({
+    expect(httpClient.requestText).toHaveBeenCalledWith({
       url: 'http://url/calendars/events/123456.ics',
       method: 'DELETE',
       headers: {


### PR DESCRIPTION
Partially resolves https://github.com/linagora/calendar-next-gen/issues/8.